### PR TITLE
vulkan-loader: fix evaluation without source

### DIFF
--- a/pkgs/development/libraries/vulkan-loader/default.nix
+++ b/pkgs/development/libraries/vulkan-loader/default.nix
@@ -11,12 +11,7 @@ let
     rev = "sdk-${version}";
     sha256 = "157m746hc76xrxd3qq0f44f5dy7pjbz8cx74ykqrlbc7rmpjpk58";
   };
-  getRev = name: builtins.substring 0 40 (builtins.readFile "${src}/${name}_revision");
 in
-
-assert getRev "spirv-tools" == spirv-tools.src.rev;
-assert getRev "spirv-headers" == spirv-tools.headers.rev;
-assert getRev "glslang" == glslang.src.rev;
 
 stdenv.mkDerivation rec {
   name = "vulkan-loader-${version}";
@@ -30,6 +25,15 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     "-DBUILD_WSI_WAYLAND_SUPPORT=ON" # XLIB/XCB supported by default
   ];
+
+  preConfigure = ''
+    checkRev() {
+      [ "$2" = $(cat "$1_revision") ] || (echo "ERROR: dependency $1 is revision $2 but should be revision" $(cat "$1_revision") && exit 1)
+    }
+    checkRev spirv-tools "${spirv-tools.src.rev}"
+    checkRev spirv-headers "${spirv-tools.headers.rev}"
+    checkRev glslang "${glslang.src.rev}"
+  '';
 
   installPhase = ''
     mkdir -p $out/lib


### PR DESCRIPTION
This replaces the poorly conceived evaluation-time asserts with preConfigure checks
